### PR TITLE
extended variable support for linked postgres

### DIFF
--- a/bin/start.sh
+++ b/bin/start.sh
@@ -193,7 +193,7 @@ associate_postgresql() {
 		POSTGRES_PORT=5432
 	fi
 	# Use default port if none specified
-	: ${POSTGRES_PORT:=5432}"
+	: ${POSTGRES_PORT:=5432}
     	
 	# if we're linked to Postgres and thus have credentials already, let's use them
 	: ${POSTGRES_USER:=${POSTGRES_ENV_POSTGRES_USER:-postgres}}


### PR DESCRIPTION
- adding support for leveraging `POSTGRES_ENV_POSTGRES_USER`, `$POSTGRES_ENV_POSTGRES_PASSWORD` and `POSTGRES_ENV_POSTGRES_DB` for linked
- removed deprecated environmental variables `POSTGRES_NAME`, `POSTGRES_PORT_5432_TCP_ADDR` and `POSTGRES_PORT_5432_TCP_PORT`.
